### PR TITLE
app: add app.ID exposed to the platform.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,10 +15,28 @@ import (
 // Set with the go linker flag -X.
 var extraArgs string
 
+// ID is the app id exposed to the platform.
+//
+// On Android ID is the package property of AndroidManifest.xml,
+// on iOS ID is the CFBundleIdentifier of the app Info.plist,
+// on Wayland it is the toplevel app_id,
+// on X11 it is the X11 XClassHint
+//
+// ID is set by the gogio tool or manually with the -X linker flag:
+//
+// EXAMPLE: gogio -ldflags="-X 'gioui.org/app.ID=org.gioui.example.Kitchen'" .
+//
+// Note that ID is treated as a constant, and that changing it at runtime
+// is not supported. Default value of ID is filepath.Base(os.Args[0]).
+var ID = ""
+
 func init() {
 	if extraArgs != "" {
 		args := strings.Split(extraArgs, "|")
 		os.Args = append(os.Args, args...)
+	}
+	if ID == "" {
+		ID = filepath.Base(os.Args[0])
 	}
 }
 

--- a/app/os_wayland.go
+++ b/app/os_wayland.go
@@ -374,6 +374,11 @@ func (d *wlDisplay) createNativeWindow(options []Option) (*window, error) {
 		w.destroy()
 		return nil, errors.New("wayland: xdg_surface_get_toplevel failed")
 	}
+
+	id := C.CString(ID)
+	C.xdg_toplevel_set_app_id(w.topLvl, id)
+	C.free(unsafe.Pointer(id))
+
 	cursorTheme := C.CString(os.Getenv("XCURSOR_THEME"))
 	defer C.free(unsafe.Pointer(cursorTheme))
 	cursorSize := 32

--- a/app/os_x11.go
+++ b/app/os_x11.go
@@ -30,8 +30,6 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"os"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -793,7 +791,7 @@ func newX11Window(gioWin *callbacks, options []Option) error {
 	hints.flags = C.InputHint
 	C.XSetWMHints(dpy, win, &hints)
 
-	name := C.CString(filepath.Base(os.Args[0]))
+	name := C.CString(ID)
 	defer C.free(unsafe.Pointer(name))
 	wmhints := C.XClassHint{name, name}
 	C.XSetClassHint(dpy, win, &wmhints)


### PR DESCRIPTION
Allow app ID to be set by linger flag -X gioui.org/app.ID=%s so that wayland can group windows, search for ${gioui.org/app.ID}.desktop file and display application name. e.g. /usr/share/applications/${gioui.org/app.ID}.desktop ~/.local/share/applications/${appID}.desktop.

On Android ID is the package property of AndroidManifest.xml, on iOS ID is the CFBundleIdentifier of the app Info.plist, on Wayland it is the toplevel app_id,
on X11 it is the X11 XClassHint

Defaults to filepath.Base(os.Args[0])

Signed-off-by: Marko Kungla <marko.kungla@gmail.com>